### PR TITLE
Add reusable project header with Home navigation

### DIFF
--- a/src/projects.json
+++ b/src/projects.json
@@ -4,5 +4,17 @@
     "description": "Classic Minesweeper game built with vanilla JS.",
     "link": "projects/minesweeper.html",
     "image": "https://via.placeholder.com/300x150"
+  },
+  {
+    "title": "Bookmarks",
+    "description": "Collection of useful bookmarks.",
+    "link": "projects/bookmarks.html",
+    "image": "https://via.placeholder.com/300x150"
+  },
+  {
+    "title": "Tools",
+    "description": "Handy tools for everyday tasks.",
+    "link": "projects/tools.html",
+    "image": "https://via.placeholder.com/300x150"
   }
 ]

--- a/src/projects/bookmarks.html
+++ b/src/projects/bookmarks.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Bookmarks</title>
+  <link rel="stylesheet" href="../styles/styles.css">
+</head>
+<body>
+  <main>
+    <h1>Bookmarks</h1>
+    <!-- Bookmark content will go here -->
+  </main>
+  <script src="header.js"></script>
+</body>
+</html>

--- a/src/projects/header.html
+++ b/src/projects/header.html
@@ -1,0 +1,5 @@
+<header>
+  <nav>
+    <a href="../index.html">Home</a>
+  </nav>
+</header>

--- a/src/projects/header.js
+++ b/src/projects/header.js
@@ -1,0 +1,6 @@
+fetch('header.html')
+  .then(response => response.text())
+  .then(html => {
+    document.body.insertAdjacentHTML('afterbegin', html);
+  })
+  .catch(err => console.error('Error loading header:', err));

--- a/src/projects/minesweeper.html
+++ b/src/projects/minesweeper.html
@@ -21,6 +21,7 @@
         <p id="consecutive-wins">Consecutive Wins: <span id="wins-count">0</span></p>
         <div id="game-board"></div>
     </main>
+    <script src="header.js"></script>
     <script src="../scripts/script.js"></script>
 </body>
 

--- a/src/projects/tools.html
+++ b/src/projects/tools.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Tools</title>
+  <link rel="stylesheet" href="../styles/styles.css">
+</head>
+<body>
+  <main>
+    <h1>Tools</h1>
+    <!-- Tools content will go here -->
+  </main>
+  <script src="header.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add reusable HTML header snippet with Home link and loader script
- create Bookmarks and Tools pages importing the shared header
- register new pages and header usage across projects for easy navigation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6896f70c4904832a8b2ef1272f8bd601