### PR TITLE
feat: allow selecting themes

### DIFF
--- a/src/scripts/landing.js
+++ b/src/scripts/landing.js
@@ -41,6 +41,32 @@ function init(projects) {
   const container = document.getElementById('projects');
   const controls = document.getElementById('settings-controls');
 
+  function addThemeSelector() {
+    const row = document.createElement('div');
+    row.className = 'settings-row';
+    const label = document.createElement('label');
+    label.textContent = 'Theme';
+    const select = document.createElement('select');
+    Object.keys(window.PRESET_THEMES).forEach(name => {
+      const opt = document.createElement('option');
+      opt.value = name;
+      opt.textContent = name.charAt(0).toUpperCase() + name.slice(1);
+      if (themeConfig.current === name) opt.selected = true;
+      select.appendChild(opt);
+    });
+    select.addEventListener('change', () => {
+      const preset = window.PRESET_THEMES[select.value];
+      themeConfig.landing = JSON.parse(JSON.stringify(preset.landing || {}));
+      themeConfig.projects = JSON.parse(JSON.stringify(preset.projects || {}));
+      themeConfig.current = select.value;
+      saveThemeConfig();
+      location.reload();
+    });
+    label.appendChild(select);
+    row.appendChild(label);
+    controls.appendChild(row);
+  }
+
   function addColorControl(labelText, value, onChange) {
     const row = document.createElement('div');
     row.className = 'settings-row';
@@ -51,6 +77,7 @@ function init(projects) {
     input.value = value;
     input.addEventListener('input', () => {
       onChange(input.value);
+      themeConfig.current = 'custom';
       saveThemeConfig();
     });
     label.appendChild(input);
@@ -67,6 +94,8 @@ function init(projects) {
   const order = stored.order || projects.map(p => p.title);
   const visibility = stored.visibility || {};
   const icons = stored.icons || {};
+
+  addThemeSelector();
 
   const landingTheme = themeConfig.landing || {};
   addColorControl('Landing Background', landingTheme.background || '#f4f4f4', v => {
@@ -177,6 +206,7 @@ function init(projects) {
         themeConfig.projects[project.title] = projectTheme;
         const tileEl = container.querySelector(`[data-title="${project.title}"]`);
         apply(tileEl, input.value);
+        themeConfig.current = 'custom';
         saveThemeConfig();
       });
       row.appendChild(input);

--- a/src/scripts/theme.js
+++ b/src/scripts/theme.js
@@ -8,6 +8,18 @@
     projects: {}
   };
 
+  const PRESET_THEMES = {
+    default: DEFAULT_THEME,
+    dark: {
+      landing: {
+        background: '#222',
+        header: '#000',
+        headerText: '#fff'
+      },
+      projects: {}
+    }
+  };
+
   let theme;
   try {
     theme = JSON.parse(localStorage.getItem('themeConfig')) || DEFAULT_THEME;
@@ -16,6 +28,8 @@
   }
 
   window.themeConfig = theme;
+  window.PRESET_THEMES = PRESET_THEMES;
+  if (!theme.current) theme.current = 'default';
 
   function applyTheme() {
     const project = document.body.dataset.project || 'landing';

--- a/src/styles/landing.css
+++ b/src/styles/landing.css
@@ -49,6 +49,11 @@ input, textarea, select {
   flex: 1;
 }
 
+#settings-controls .settings-row select {
+  margin-left: 0.5rem;
+  flex: 1;
+}
+
 .projects-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));


### PR DESCRIPTION
## Summary
- add preset theme definitions and expose them globally
- introduce theme selector and mark custom themes on color changes
- style select controls in settings menu

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a72f45894832a9f08f24a9b3e7a66