### PR TITLE
Add Minesweeper status bar and difficulty options

### DIFF
--- a/src/projects/minesweeper.html
+++ b/src/projects/minesweeper.html
@@ -14,11 +14,18 @@
     <main>
         <h1>Minesweeper</h1>
         <div class="game-controls">
-            <label for="board-size">Board size: </label>
-            <input id="board-size" type="number" min="1" max="50" value="8" placeholder="Size">
-            <label for="mine-count">Mines: </label>
-            <input id="mine-count" type="number" min="1" max="2500" value="10" placeholder="Mines">
+            <label for="difficulty">Difficulty:</label>
+            <select id="difficulty">
+                <option value="easy">Easy</option>
+                <option value="medium">Medium</option>
+                <option value="hard">Hard</option>
+            </select>
             <button id="start-game">Start Game</button>
+        </div>
+        <div class="status-bar">
+            <span>Mines left: <span id="mines-left">0</span></span>
+            <button id="restart-game">Restart</button>
+            <span>Time: <span id="timer">0</span>s</span>
         </div>
         <p id="consecutive-wins">Consecutive Wins: <span id="wins-count">0</span></p>
         <div id="game-board"></div>

--- a/src/styles/styles.css
+++ b/src/styles/styles.css
@@ -45,12 +45,25 @@ main {
 .game-controls {
     display: flex;
     justify-content: center;
+    align-items: center;
     margin-bottom: 1rem;
 }
 
-.game-controls input {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+.game-controls select {
+    margin: 0 0.5rem;
+}
+
+.status-bar {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    width: 80%;
+    margin: 0 auto 1rem;
+}
+
+.status-bar button,
+.status-bar span {
+    margin: 0 0.5rem;
 }
 
 #consecutive-wins {


### PR DESCRIPTION
## Summary
- add predefined difficulty levels and status bar with timer, mines counter, and restart control
- track flags to update remaining mines and reset the clock for each game
- style new controls and status bar for Minesweeper page

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c0beaeb398832a863f25ff8d636e23