### PR TITLE
refactor: introduce shared responsive header

### DIFF
--- a/src/components/header.html
+++ b/src/components/header.html
@@ -1,0 +1,13 @@
+<header class="site-header">
+  <div class="branding">
+    <i class="fa-solid fa-diagram-project"></i>
+    <span>My Projects</span>
+  </div>
+  <nav class="nav-links">
+    <a class="home-link" href="index.html"><i class="fa-solid fa-house"></i> Home</a>
+  </nav>
+  <div class="header-controls">
+    <button id="theme-toggle" aria-label="Toggle Theme"><i class="fa-solid fa-circle-half-stroke"></i></button>
+    <button id="settings-btn" aria-label="Settings"><i class="fa-solid fa-cog"></i></button>
+  </div>
+</header>

--- a/src/index.html
+++ b/src/index.html
@@ -8,10 +8,6 @@
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" crossorigin="anonymous" referrerpolicy="no-referrer" />
 </head>
 <body data-project="landing">
-  <header>
-    <h1><i class="fa-solid fa-diagram-project"></i> My Projects</h1>
-    <button id="settings-btn" aria-label="Settings"><i class="fa-solid fa-cog"></i></button>
-  </header>
   <main id="projects" class="projects-grid"></main>
 
   <div id="settings-modal" class="modal">
@@ -22,6 +18,7 @@
     </div>
   </div>
   <script src="scripts/theme.js"></script>
+  <script src="projects/header.js"></script>
   <script src="scripts/landing.js"></script>
 </body>
 </html>

--- a/src/projects/header.html
+++ b/src/projects/header.html
@@ -1,5 +1,0 @@
-<header>
-  <nav>
-    <a href="../index.html"><i class="fa-solid fa-house"></i> Home</a>
-  </nav>
-</header>

--- a/src/projects/header.js
+++ b/src/projects/header.js
@@ -1,6 +1,33 @@
-fetch('header.html')
-  .then(response => response.text())
-  .then(html => {
-    document.body.insertAdjacentHTML('afterbegin', html);
-  })
-  .catch(err => console.error('Error loading header:', err));
+(function() {
+  const base = window.location.pathname.includes('/projects/') ? '../' : '';
+  try {
+    const req = new XMLHttpRequest();
+    req.open('GET', base + 'components/header.html', false);
+    req.send(null);
+    if (req.status >= 200 && req.status < 300) {
+      document.body.insertAdjacentHTML('afterbegin', req.responseText);
+      const homeLink = document.querySelector('.home-link');
+      if (homeLink) homeLink.href = base + 'index.html';
+      if (!document.getElementById('settings-modal')) {
+        const settingsBtn = document.getElementById('settings-btn');
+        if (settingsBtn) settingsBtn.style.display = 'none';
+      }
+      const themeToggle = document.getElementById('theme-toggle');
+      if (themeToggle) {
+        themeToggle.addEventListener('click', () => {
+          const next = themeConfig.current === 'dark' ? 'default' : 'dark';
+          const preset = PRESET_THEMES[next];
+          themeConfig.landing = JSON.parse(JSON.stringify(preset.landing || {}));
+          themeConfig.projects = JSON.parse(JSON.stringify(preset.projects || {}));
+          themeConfig.current = next;
+          saveThemeConfig();
+          applyTheme();
+        });
+      }
+    } else {
+      console.error('Error loading header:', req.statusText);
+    }
+  } catch (err) {
+    console.error('Error loading header:', err);
+  }
+})();

--- a/src/styles/landing.css
+++ b/src/styles/landing.css
@@ -19,14 +19,55 @@ header {
   display: flex;
   justify-content: space-between;
   align-items: center;
+  flex-wrap: wrap;
 }
 
-#settings-btn {
+header .branding {
+  display: flex;
+  align-items: center;
+  font-size: 1.5rem;
+}
+
+header .branding i {
+  margin-right: 0.5rem;
+}
+
+header nav {
+  display: flex;
+  gap: 1rem;
+}
+
+header nav a {
+  color: var(--landing-header-text);
+  text-decoration: none;
+}
+
+.header-controls {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.header-controls button {
   background: none;
   border: none;
   color: var(--landing-header-text);
   font-size: 1.5rem;
   cursor: pointer;
+}
+
+@media (max-width: 600px) {
+  header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+  header nav {
+    margin-top: 0.5rem;
+    flex-direction: column;
+    width: 100%;
+  }
+  .header-controls {
+    align-self: flex-end;
+  }
 }
 
 input, textarea, select {

--- a/src/styles/styles.css
+++ b/src/styles/styles.css
@@ -21,11 +21,55 @@ header {
     display: flex;
     justify-content: space-between;
     align-items: center;
+    flex-wrap: wrap;
+}
+
+header .branding {
+    display: flex;
+    align-items: center;
+    font-size: 1.5rem;
+}
+
+header .branding i {
+    margin-right: 0.5rem;
+}
+
+header nav {
+    display: flex;
+    gap: 1rem;
 }
 
 header nav a {
     color: var(--header-text);
     text-decoration: none;
+}
+
+.header-controls {
+    display: flex;
+    gap: 0.5rem;
+}
+
+.header-controls button {
+    background: none;
+    border: none;
+    color: var(--header-text);
+    font-size: 1.2rem;
+    cursor: pointer;
+}
+
+@media (max-width: 600px) {
+    header {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+    header nav {
+        margin-top: 0.5rem;
+        flex-direction: column;
+        width: 100%;
+    }
+    .header-controls {
+        align-self: flex-end;
+    }
 }
 
 input, textarea, select {


### PR DESCRIPTION
## Summary
- create reusable header component with branding, navigation, and theme controls
- load header on all pages with a script that handles paths and theme toggling
- style the header for responsiveness and small screens

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c0bf68c810832aa89cf46a9aaf308c