### PR TITLE
Make Minesweeper responsive for mobile

### DIFF
--- a/src/styles/styles.css
+++ b/src/styles/styles.css
@@ -38,7 +38,8 @@ h1 {
 }
 
 main {
-    width: 80%;
+    width: 90%;
+    max-width: 600px;
     margin: 0 auto;
 }
 
@@ -57,8 +58,10 @@ main {
     display: flex;
     justify-content: space-between;
     align-items: center;
-    width: 80%;
+    width: 100%;
     margin: 0 auto 1rem;
+    flex-wrap: wrap;
+    gap: 0.5rem;
 }
 
 .status-bar button,
@@ -77,11 +80,12 @@ main {
     align-items: center;
     padding: 20px;
     margin: 0 auto;
+    width: 100%;
 }
 
 .cell {
-    width: 40px;
-    height: 40px;
+    width: 100%;
+    aspect-ratio: 1 / 1;
     border: 1px solid var(--primary-color);
     border-radius: 5px;
     display: flex;
@@ -160,4 +164,11 @@ textarea {
 select, button {
     padding: 0.5rem;
     margin: 0.5rem;
+}
+
+@media (max-width: 600px) {
+    #game-board {
+        gap: 5px;
+        padding: 10px;
+    }
 }


### PR DESCRIPTION
## Summary
- Improve layout for Minesweeper on small screens with flexible widths
- Let status bar wrap and fit mobile displays
- Use square, responsive cells and adjust gaps for narrow viewports

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c0ce6aec68832aba58ccbf5e09e585