### PR TITLE
Add export/import functionality for settings

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -25,10 +25,17 @@
     <div class="modal-content">
       <span id="settings-close" class="close">&times;</span>
       <h2>Settings</h2>
-      <div id="settings-controls"></div>
+      <div id="settings-controls">
+        <div class="settings-row">
+          <button id="export-settings">Export Settings</button>
+          <button id="import-settings">Import Settings</button>
+          <input type="file" id="import-settings-file" accept="application/json" style="display:none" />
+        </div>
+      </div>
     </div>
   </div>
   <script src="scripts/theme.js"></script>
+  <script src="scripts/storage.js"></script>
   <script src="scripts/landing.js"></script>
 </body>
 </html>

--- a/src/scripts/landing.js
+++ b/src/scripts/landing.js
@@ -5,6 +5,9 @@ const profileSection = document.getElementById('profile-section');
 const profilePic = document.getElementById('profile-picture');
 const profileNameEl = document.getElementById('profile-name');
 const profileDetailsEl = document.getElementById('profile-details');
+const exportSettingsBtn = document.getElementById('export-settings');
+const importSettingsBtn = document.getElementById('import-settings');
+const importSettingsFile = document.getElementById('import-settings-file');
 
 let profile = {};
 try {
@@ -64,6 +67,25 @@ settingsClose.addEventListener('click', () => {
 window.addEventListener('click', e => {
   if (e.target === settingsModal) settingsModal.style.display = 'none';
 });
+
+if (exportSettingsBtn) {
+  exportSettingsBtn.addEventListener('click', () => {
+    if (typeof window.exportSettings === 'function') {
+      window.exportSettings();
+    }
+  });
+}
+
+if (importSettingsBtn && importSettingsFile) {
+  importSettingsBtn.addEventListener('click', () => importSettingsFile.click());
+  importSettingsFile.addEventListener('change', () => {
+    const file = importSettingsFile.files[0];
+    if (file && typeof window.importSettings === 'function') {
+      window.importSettings(file);
+    }
+    importSettingsFile.value = '';
+  });
+}
 
 // Initialize the page with project data
 function init(projects) {

--- a/src/scripts/storage.js
+++ b/src/scripts/storage.js
@@ -1,0 +1,40 @@
+(function() {
+  function exportSettings() {
+    try {
+      const data = {};
+      for (let i = 0; i < localStorage.length; i++) {
+        const key = localStorage.key(i);
+        data[key] = localStorage.getItem(key);
+      }
+      const dataStr = JSON.stringify(data, null, 2);
+      const blob = new Blob([dataStr], { type: 'application/json' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = 'localStorage.json';
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+    } catch (e) {
+      console.warn('Could not export settings:', e);
+    }
+  }
+
+  function importSettings(file) {
+    const reader = new FileReader();
+    reader.onload = e => {
+      try {
+        const data = JSON.parse(e.target.result);
+        Object.keys(data).forEach(key => localStorage.setItem(key, data[key]));
+        alert('Local storage restored.');
+      } catch (err) {
+        alert('Invalid local storage file.');
+      }
+    };
+    reader.readAsText(file);
+  }
+
+  window.exportSettings = exportSettings;
+  window.importSettings = importSettings;
+})();


### PR DESCRIPTION
## Summary
- add export/import buttons to settings modal
- provide `storage.js` utility to save and restore `localStorage`
- hook new buttons into landing page logic

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c0ced1dba8832a8a2dc7fd940aeeac