### PR TITLE
feat: add dynamic module loader

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -28,7 +28,7 @@
       <div id="settings-controls"></div>
     </div>
   </div>
-  <script src="scripts/theme.js"></script>
-  <script src="scripts/landing.js"></script>
+    <script src="scripts/theme.js"></script>
+    <script type="module" src="scripts/landing.js"></script>
 </body>
 </html>

--- a/src/modules/template/index.html
+++ b/src/modules/template/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Module Template</title>
+  </head>
+  <body>
+    <div id="app">Your module content goes here.</div>
+    <script type="module" src="./module.js"></script>
+  </body>
+</html>

--- a/src/modules/template/module.js
+++ b/src/modules/template/module.js
@@ -1,0 +1,14 @@
+/**
+ * Basic scaffold for a standalone module.
+ * Copy this folder and update the contents to create a new module.
+ */
+
+export function init() {
+  const root = document.getElementById('app');
+  if (root) {
+    root.textContent = 'Hello from a new module!';
+  }
+}
+
+// Automatically initialise when the script is loaded
+init();

--- a/src/projects.json
+++ b/src/projects.json
@@ -2,19 +2,19 @@
   {
     "title": "Minesweeper",
     "description": "Classic Minesweeper game built with vanilla JS.",
-    "link": "projects/minesweeper.html",
+    "entry": "projects/minesweeper.html",
     "icon": "fa-solid fa-bomb"
   },
   {
     "title": "Bookmarks",
     "description": "Collection of useful bookmarks.",
-    "link": "projects/bookmarks.html",
+    "entry": "projects/bookmarks.html",
     "icon": "fa-solid fa-bookmark"
   },
   {
     "title": "Tools",
     "description": "Handy tools for everyday tasks.",
-    "link": "projects/tools.html",
+    "entry": "projects/tools.html",
     "icon": "fa-solid fa-wrench"
   }
 ]

--- a/src/scripts/landing.js
+++ b/src/scripts/landing.js
@@ -36,19 +36,19 @@ const FALLBACK_PROJECTS = [
   {
     title: 'Minesweeper',
     description: 'Classic Minesweeper game built with vanilla JS.',
-    link: 'projects/minesweeper.html',
+    entry: 'projects/minesweeper.html',
     icon: 'fa-solid fa-bomb'
   },
   {
     title: 'Bookmarks',
     description: 'Collection of useful bookmarks.',
-    link: 'projects/bookmarks.html',
+    entry: 'projects/bookmarks.html',
     icon: 'fa-solid fa-bookmark'
   },
   {
     title: 'Tools',
     description: 'Handy tools for everyday tasks.',
-    link: 'projects/tools.html',
+    entry: 'projects/tools.html',
     icon: 'fa-solid fa-wrench'
   }
 ];
@@ -311,7 +311,7 @@ function init(projects) {
   orderedProjects.forEach(project => {
     const tile = document.createElement('a');
     tile.className = 'project-tile';
-    tile.href = project.link;
+    tile.href = project.entry;
     tile.draggable = true;
     tile.dataset.title = project.title;
     const iconClass = icons[project.title] || project.icon;
@@ -432,13 +432,21 @@ function init(projects) {
   }
 }
 
-fetch('projects.json')
-  .then(response => {
+/**
+ * Load module metadata from the manifest and initialise the landing page.
+ * This allows new modules to be added by simply updating projects.json
+ * without manually wiring them into the page.
+ */
+async function loadModules() {
+  try {
+    const response = await fetch('projects.json');
     if (!response.ok) throw new Error('Network response was not ok');
-    return response.json();
-  })
-  .then(init)
-  .catch(err => {
+    const modules = await response.json();
+    init(modules);
+  } catch (err) {
     console.error('Error loading projects:', err);
     init(FALLBACK_PROJECTS);
-  });
+  }
+}
+
+loadModules();


### PR DESCRIPTION
## Summary
- add loader that reads module manifest and populates landing tiles dynamically
- introduce `entry` field in `projects.json` and update fallback data
- provide HTML/JS template for creating new modules

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c0cedf12d0832a8997db3338a5f8ec